### PR TITLE
Check if the data type is not code to enable loading of persistent saves

### DIFF
--- a/addons/overthrow_main/functions/save/fn_loadGame.sqf
+++ b/addons/overthrow_main/functions/save/fn_loadGame.sqf
@@ -66,8 +66,10 @@ private _cc = 0;
 		{
 			if(typename _x == "ARRAY") then {
 				_y = _x select 0;
-				if((_y select [0,4]) != "ace_" and (_y select [0,4]) != "cba_" and (_y select [0,4]) != "bis_") then {
-					warehouse setVariable [_x select 0,_x,true];
+				if(typeName _y != "CODE") then {
+					if((_y select [0,4]) != "ace_" and (_y select [0,4]) != "cba_" and (_y select [0,4]) != "bis_") then {
+						warehouse setVariable [_x select 0,_x,true];
+					};
 				};
 			};
 		}foreach(_val);


### PR DESCRIPTION
Currently, if the data type is code, `_y select [0, 4]` will fail and prevent loading of persistent saves. Thus, there should be a prior check for if the data type is not code. For example, not being `{_this call ace_missileguidance_fnc_onIncomingMissile;}`.