### PR TITLE
Various Item Dupe Fixes

### DIFF
--- a/addons/overthrow_main/functions/actions/fn_dumpStuff.sqf
+++ b/addons/overthrow_main/functions/actions/fn_dumpStuff.sqf
@@ -74,7 +74,7 @@ if(primaryWeapon _unit != "") then {
 		_t addItemCargoGlobal [_x,1];
 	}foreach(primaryWeaponItems _unit);
 	removeAllPrimaryWeaponItems _unit;
-	_t addWeaponCargoGlobal [primaryWeapon _unit,1];
+	_t addWeaponCargoGlobal [(primaryWeapon _unit) call BIS_fnc_baseWeapon,1];
 	_unit removeWeapon primaryWeapon _unit;
 };
 if(_full and !_istruck) exitWith {false};

--- a/addons/overthrow_main/functions/actions/fn_transferFrom.sqf
+++ b/addons/overthrow_main/functions/actions/fn_transferFrom.sqf
@@ -43,13 +43,13 @@ _doTransfer = {
 			_count = _count + 1;
 			call {
 				if(_cls isKindOf ["Rifle",configFile >> "CfgWeapons"]) exitWith {
-					_veh addWeaponCargoGlobal [_cls,1];
+					_veh addWeaponCargoGlobal [_cls call BIS_fnc_baseWeapon,1];
 				};
 				if(_cls isKindOf ["Launcher",configFile >> "CfgWeapons"]) exitWith {
-					_veh addWeaponCargoGlobal [_cls,1];
+					_veh addWeaponCargoGlobal [_cls call BIS_fnc_baseWeapon,1];
 				};
 				if(_cls isKindOf ["Pistol",configFile >> "CfgWeapons"]) exitWith {
-					_veh addWeaponCargoGlobal [_cls,1];
+					_veh addWeaponCargoGlobal [_cls call BIS_fnc_baseWeapon,1];
 				};
 				if(_cls isKindOf ["CA_Magazine",configFile >> "CfgMagazines"]) exitWith {
 					_veh addMagazineCargoGlobal [_cls,1];

--- a/addons/overthrow_main/functions/actions/fn_transferTo.sqf
+++ b/addons/overthrow_main/functions/actions/fn_transferTo.sqf
@@ -82,13 +82,13 @@ private _doTransfer = {
 						_veh addBackpackCargoGlobal [_cls,1];
 					};
 					if(_cls isKindOf ["Rifle",configFile >> "CfgWeapons"]) exitWith {
-						_veh addWeaponCargoGlobal [_cls,1];
+						_veh addWeaponCargoGlobal [_cls call BIS_fnc_baseWeapon,1];
 					};
 					if(_cls isKindOf ["Launcher",configFile >> "CfgWeapons"]) exitWith {
-						_veh addWeaponCargoGlobal [_cls,1];
+						_veh addWeaponCargoGlobal [_cls call BIS_fnc_baseWeapon,1];
 					};
 					if(_cls isKindOf ["Pistol",configFile >> "CfgWeapons"]) exitWith {
-						_veh addWeaponCargoGlobal [_cls,1];
+						_veh addWeaponCargoGlobal [_cls call BIS_fnc_baseWeapon,1];
 					};
 					if(_cls isKindOf ["CA_Magazine",configFile >> "CfgMagazines"]) exitWith {
 						_veh addMagazineCargoGlobal [_cls,1];

--- a/addons/overthrow_main/functions/save/fn_saveGame.sqf
+++ b/addons/overthrow_main/functions/save/fn_saveGame.sqf
@@ -104,6 +104,12 @@ private _saved = 0;
 	if(!(_x isKindOf "Man") and (alive _x) and (_x call OT_fnc_hasOwner) and (typeof _x != OT_flag_IND)) then {
 		_owner = _x call OT_fnc_getOwner;
 		_s = _x call OT_fnc_unitStock;
+		
+		{
+			if(((_x call BIS_fnc_itemType) select 0) == "Weapon") then {
+				_s set [_forEachIndex, [(_x select 0) call BIS_fnc_baseWeapon, _x select 1]];
+			};
+		}foreach(_s);
 
 		if(typeof _x == OT_item_safe) then {
 			_s pushback ["money",_x getVariable ["money",0]];


### PR DESCRIPTION
Various changes that prevent duplication of weapon attachments due to Arma compound weapon names, by effectively stripping attachments to separate objects.