### PR TITLE
Add weapon magazine to stock

### DIFF
--- a/addons/overthrow_main/functions/fn_unitStock.sqf
+++ b/addons/overthrow_main/functions/fn_unitStock.sqf
@@ -37,6 +37,11 @@ private _allCargo = {
 						_myitems pushback _x;
 					};
 				};
+				if(typename _x == "ARRAY") then {
+					if !((_x select 0) isEqualTo "") then {
+						_myitems pushback (_x select 0);
+					};
+				};
 			}foreach(_x);
 		}foreach(weaponsItemsCargo _target);
 		{


### PR DESCRIPTION
This should prevent loaded magazines from being lost. NOTE: Currently converts all mags to full mags, regardless of actual remaining ammo.  This is consistent with how non-loaded mags are handled.