### PR TITLE
Prevent error if disabling ACE Advanced Fatigue

### DIFF
--- a/addons/overthrow_main/functions/player/fn_setupPlayer.sqf
+++ b/addons/overthrow_main/functions/player/fn_setupPlayer.sqf
@@ -1,6 +1,8 @@
 player spawn OT_fnc_statsSystem;
 player spawn OT_fnc_wantedSystem;
-player spawn OT_fnc_perkSystem;
+if !(isNil "ace_advanced_fatigue_anreserve") then {
+	player spawn OT_fnc_perkSystem;
+};
 player spawn OT_fnc_mapSystem;
 disableUserInput false;
 


### PR DESCRIPTION
Prevent `Undefined variable in expression: ace_advanced_fatigue_enabled` error in `fn_perkSystem.sqf` by never spawning `OT_fnc_perkSystem` in `fn_setupPlayer.sqf` when `ace_advanced_fatigue_anreserve` is undefined. It will be undefined if the host has disabled [ACE Advanced Fatigue](https://ace3mod.com/wiki/feature/advanced-fatigue.html).