### PR TITLE
Move body deletion until after weapon looting

### DIFF
--- a/addons/overthrow_main/functions/AI/orders/fn_orderLoot.sqf
+++ b/addons/overthrow_main/functions/AI/orders/fn_orderLoot.sqf
@@ -75,7 +75,6 @@ format["Looting nearby bodies into the %1",(typeof _target) call OT_fnc_vehicleG
 
 			[_deadguy,_unit] call OT_fnc_takeStuff;
 			sleep 2;
-            deleteVehicle _deadguy;
 			if(primaryWeapon _unit == "") then {
 				_weapon = objNull;
 				{
@@ -102,6 +101,7 @@ format["Looting nearby bodies into the %1",(typeof _target) call OT_fnc_vehicleG
 					};
 				};
 			};
+			deleteVehicle _deadguy;
 			if(!alive _unit) exitWith {};
 			_timeout = time + 120;
 			_unit doMove getpos _t;


### PR DESCRIPTION
This will prevent loot completion failure, primary weapons will now be looted properly, and looting will not be interrupted.