### PR TITLE
Fixes for pre-loaded missile dummy dupes

### DIFF
--- a/addons/overthrow_main/functions/actions/fn_transferFrom.sqf
+++ b/addons/overthrow_main/functions/actions/fn_transferFrom.sqf
@@ -35,6 +35,16 @@ _doTransfer = {
 	// Dummy CBA remove calls to strip weapons and replace with non-preset types
 	[_target, "Bag_Base"] call CBA_fnc_removeBackpackCargo;
 	[_target, "FakeWeapon"] call CBA_fnc_removeWeaponCargo;
+	
+	// Strip out preloaded missile dummies from inventory.
+	// Only way to really clear them is a full magazine clear.
+	private _mags = magazineCargo _target;
+	_mags = _mags - OT_noCopyMags;
+	clearMagazineCargoGlobal _target;
+	{
+		_target addMagazineCargoGlobal[_x, 1];
+	}foreach(_mags);
+	
 	{
 		_count = 0;
 		_cls = _x select 0;

--- a/addons/overthrow_main/functions/actions/fn_transferTo.sqf
+++ b/addons/overthrow_main/functions/actions/fn_transferTo.sqf
@@ -56,6 +56,16 @@ private _doTransfer = {
 	// Dummy CBA remove calls to strip weapons and replace with non-preset types
 	[_target, "Bag_Base"] call CBA_fnc_removeBackpackCargo;
 	[_target, "FakeWeapon"] call CBA_fnc_removeWeaponCargo;
+	
+	// Strip out preloaded missile dummies from inventory.
+	// Only way to really clear them is a full magazine clear.
+	private _mags = magazineCargo _target;
+	_mags = _mags - OT_noCopyMags;
+	clearMagazineCargoGlobal _target;
+	{
+		_target addMagazineCargoGlobal[_x, 1];
+	}foreach(_mags);
+	
 	if(_iswarehouse) then {
 		{
 			_cls = _x select 0;

--- a/addons/overthrow_main/functions/fn_initVar.sqf
+++ b/addons/overthrow_main/functions/fn_initVar.sqf
@@ -893,6 +893,8 @@ OT_regions = [];
 
 OT_cigsArray = ["EWK_Cigar1", "EWK_Cigar2", "EWK_Cig1", "EWK_Cig2", "EWK_Cig3", "EWK_Cig4", "EWK_Glasses_Cig1", "EWK_Glasses_Cig2", "EWK_Glasses_Cig3", "EWK_Glasses_Cig4", "EWK_Glasses_Shemag_GRE_Cig6", "EWK_Glasses_Shemag_NB_Cig6", "EWK_Glasses_Shemag_tan_Cig6", "EWK_Cig5", "EWK_Glasses_Cig5", "EWK_Cig6", "EWK_Glasses_Cig6", "EWK_Shemag_GRE_Cig6", "EWK_Shemag_NB_Cig6", "EWK_Shemag_tan_Cig6", "murshun_cigs_cig0", "murshun_cigs_cig1", "murshun_cigs_cig2", "murshun_cigs_cig3", "murshun_cigs_cig4"];
 
+// Weapon mags to delete or not copy on transfers.
+OT_noCopyMags = ["ACE_PreloadedMissileDummy"];
 
 if(isServer) then {
 	cost setVariable ["ToolKit",[80,0,0,0],true];

--- a/addons/overthrow_main/functions/fn_unitStock.sqf
+++ b/addons/overthrow_main/functions/fn_unitStock.sqf
@@ -72,6 +72,7 @@ private _allCargo = {
 		}foreach(everyContainer _target);
 	};
 	if(isnil "_myitems") then {_myitems = []};
+	_myitems = _myitems - OT_noCopyMags;
 	_myitems
 };
 


### PR DESCRIPTION
Preloaded missile dummies would pile up in the tens of thousands in some cases, this should hopefully fix that, as well as clear out any of the ones already piled.