### PR TITLE
Fix object positioning when saving/loading games

### DIFF
--- a/addons/overthrow_main/functions/UI/dialogs/fn_mainMenu.sqf
+++ b/addons/overthrow_main/functions/UI/dialogs/fn_mainMenu.sqf
@@ -85,7 +85,6 @@ if(typename _b isEqualTo "ARRAY") then {
 	_txt = "";
 
 	if(_building call OT_fnc_hasOwner) then {
-
 		_owner = _building call OT_fnc_getOwner;
 		_ownername = players_NS getVariable format["name%1",_owner];
 		if(isNil "_ownername") then {_ownername = "Someone"};
@@ -309,7 +308,9 @@ if(typename _b isEqualTo "ARRAY") then {
 		};
 	};
 
-	if(!((typeof _building) in OT_allRealEstate + [OT_flag_IND])) then {
+	// Fetch the list of buildable houses
+	private _buildableHouses = (OT_Buildables param [9, []]) param [2, []];
+	if(!((typeof _building) in OT_allRealEstate + [OT_flag_IND]) and {!(typeOf _building in _buildableHouses)}) then {
 		ctrlEnable [1609,false];
 		ctrlEnable [1610,false];
 		ctrlEnable [1608,false];

--- a/addons/overthrow_main/functions/actions/fn_build.sqf
+++ b/addons/overthrow_main/functions/actions/fn_build.sqf
@@ -267,6 +267,7 @@ buildOnMouseUp = {
 			if(_money < modePrice) then {
 				"You cannot afford that" call OT_fnc_notifyMinor;
 			}else{
+
 				_created = objNULL;
 				playSound "3DEN_notificationDefault";
 				player setVariable ["money",_money-modePrice,true];
@@ -279,6 +280,7 @@ buildOnMouseUp = {
 						clearItemCargoGlobal _x;
 						[_x,getplayeruid player] call OT_fnc_setOwner;
 						_x call OT_fnc_initObjectLocal;
+
 					}foreach(_objects);
 					_created = _objects select 0;
 					deleteVehicle modeTarget;
@@ -286,6 +288,12 @@ buildOnMouseUp = {
 					_created = modeTarget;
 					[modeTarget,getplayeruid player] call OT_fnc_setOwner;
 					modeTarget = objNull;
+				};
+
+				// If the object is a house, mark it as being player-built (will be used to save the leasing status)
+				private _buildableHouses = (OT_Buildables param [9, []]) param [2, []];
+				if ((typeof _created) in _buildableHouses) then {
+					_created setVariable ["OT_house_isPlayerBuilt", true, true];
 				};
 
 				if(modeCode != "") then {

--- a/addons/overthrow_main/functions/actions/fn_leaseBuilding.sqf
+++ b/addons/overthrow_main/functions/actions/fn_leaseBuilding.sqf
@@ -56,6 +56,12 @@ if(typename _b isEqualTo "ARRAY") then {
 };
 if(_err) exitWith {};
 if(_handled) then {
+
+	// If the house is player-built, we set its lease variable to true
+	if (_building getVariable ["OT_house_isPlayerBuilt", false]) then {
+		_building setVariable ["OT_house_isLeased", true, true];
+	};
+
 	private _id = ([_building] call OT_fnc_getBuildID);
 	_leased = player getvariable ["leased",[]];
 	_leased pushback _id;

--- a/addons/overthrow_main/functions/factions/GUER/fn_GUERLoop.sqf
+++ b/addons/overthrow_main/functions/factions/GUER/fn_GUERLoop.sqf
@@ -332,11 +332,11 @@ if ((date select 4) != _lastmin) then {
 						[-_costtoproduce] call OT_fnc_resistanceFunds;
 						_timespent = _timespent + 1;
 					}else{
-                        _need = "";
-                        if !(_dowood) then {_need = _need + format["%1 x wood ",_wood]};
-                        if !(_dosteel) then {_need = _need + format["%1 x steel ",_steel]};
-                        if !(_doplastic) then {_need = _need + format["%1 x plastic ",_plastic]};
-                        if !(_domoney) then {_need = _need + format["$%1 resistance funds",_costtoproduce]};
+                        			_need = "";
+			                        if !(_dowood) then {_need = _need + format["%1 x wood ",_wood]};
+			                        if !(_dosteel) then {_need = _need + format["%1 x steel ",_steel]};
+			                        if !(_doplastic) then {_need = _need + format["%1 x plastic ",_plastic]};
+			                        if !(_domoney) then {_need = _need + format["$%1 resistance funds",_costtoproduce]};
 						format["Factory has insufficient resources to produce item (need: %1)",_need] remoteExec["OT_fnc_notifyMinor",0,false];
 						spawner setVariable ["GEURproduceerror",format["Factory has insufficient resources to produce item (need: %1)",_need],true];
 					};
@@ -363,7 +363,8 @@ if ((date select 4) != _lastmin) then {
 						_p = OT_factoryVehicleSpawn findEmptyPosition [5,100,_currentCls];
 						if(count _p > 0) then {
 							_veh = _currentCls createVehicle _p;
-							[_veh,(server getVariable ["generals",[]]) select 0] call OT_fnc_setOwner;
+							//[_veh,(server getVariable ["generals",[]]) select 0] call OT_fnc_setOwner;
+							_veh setVariable ["OT_forceSaveUnowned", true, false];		// Save this vehicle even if it is unowned (we know somebody must have requested it at the factory, so they'll come back and claim it... eventually)
 							clearWeaponCargoGlobal _veh;
 							clearMagazineCargoGlobal _veh;
 							clearBackpackCargoGlobal _veh;

--- a/addons/overthrow_main/functions/factions/GUER/fn_GUERLoop.sqf
+++ b/addons/overthrow_main/functions/factions/GUER/fn_GUERLoop.sqf
@@ -364,7 +364,7 @@ if ((date select 4) != _lastmin) then {
 						if(count _p > 0) then {
 							_veh = _currentCls createVehicle _p;
 							//[_veh,(server getVariable ["generals",[]]) select 0] call OT_fnc_setOwner;
-							_veh setVariable ["OT_forceSaveUnowned", true, false];		// Save this vehicle even if it is unowned (we know somebody must have requested it at the factory, so they'll come back and claim it... eventually)
+							_veh setVariable ["OT_forceSaveUnowned", true, true];		// Save this vehicle even if it is unowned (we know somebody must have requested it at the factory, so they'll come back and claim it... eventually)
 							clearWeaponCargoGlobal _veh;
 							clearMagazineCargoGlobal _veh;
 							clearBackpackCargoGlobal _veh;

--- a/addons/overthrow_main/functions/save/fn_loadGame.sqf
+++ b/addons/overthrow_main/functions/save/fn_loadGame.sqf
@@ -142,6 +142,7 @@ sleep 0.3;
 			if !(_type isKindOf "Man") then {
 				_pos = ((_x select 1)#0);
 				_simulation = ((_x select 1)#1);
+				_posFormat = (_x select 1) param [2, 0];		// Assume format 0 by default (posATL)
 				_dir = _x select 2;
 				_stock = _x select 3;
 				_owner = _x select 4;
@@ -149,7 +150,6 @@ sleep 0.3;
 				if(count _x > 5) then {
 					_name = _x select 5;
 				};
-				private _p = _pos;
 				_veh = createVehicle [_type, [0,0,1000], [], 0, "CAN_COLLIDE"];
 				if !(_type isKindOf "LandVehicle" || _type isKindOf "Air" || _type isKindOf "Ship") then {
 					_veh enableDynamicSimulation true;
@@ -197,13 +197,19 @@ sleep 0.3;
 						};
 					};
 				};
-				if(typename _dir isEqualTo "SCALAR") then {
+
+				if (_posFormat == 1) then {
+					_veh setPosWorld _pos;		// format 1 is the new posWorld format
+				} else {
+					_veh setPosATL _pos;		// <= v0.7.8.5 save - use the old posATL format
+				};
+
+				if(_dir isEqualType 0) then {
 					//Pre 0.6.8 save, scalar direction
 					_veh setDir _dir;
 				}else{
 					_veh setVectorDirAndUp _dir;
 				};
-				_veh setPosATL _p;
 				if(_type isKindOf "Building") then {
 					_clu = createVehicle ["Land_ClutterCutter_large_F", _pos, [], 0, "CAN_COLLIDE"];
 					_clu enableDynamicSimulation true;

--- a/addons/overthrow_main/functions/save/fn_loadGame.sqf
+++ b/addons/overthrow_main/functions/save/fn_loadGame.sqf
@@ -28,7 +28,10 @@ private _cc = 0;
 
 sleep 0.3;
 
+
 //now do everything else
+private _buildableHouses = [];
+private _hasList_buildableHouses = false;
 {
 	_x params ["_key","_val"];
 
@@ -198,9 +201,17 @@ sleep 0.3;
 					};
 				};
 
+				// Fetch the list of buildable houses
+				if (!_hasList_buildableHouses) then {
+					if (!isNil "OT_Buildables") then {
+						_buildableHouses = (OT_Buildables param [9, []]) param [2, []];
+						_hasList_buildableHouses = true;
+					};
+				};
+
 				// If the object is a player-built house, fetch its variables
 				private _houseParams = _x param [8, []];
-				if !(_houseParams isEqualTo []) then {
+				if (!(_houseParams isEqualTo []) or {_type in _buildableHouses}) then {
 					_veh setVariable ["OT_house_isPlayerBuilt", true, true];
 
 					private _isLeased = _houseParams param [0, false];

--- a/addons/overthrow_main/functions/save/fn_loadGame.sqf
+++ b/addons/overthrow_main/functions/save/fn_loadGame.sqf
@@ -221,7 +221,14 @@ sleep 0.3;
 				clearItemCargoGlobal _veh;
 				_veh setVariable ["name",_name,true];
 
-				[_veh,_owner] call OT_fnc_setOwner;
+				// If this vehicle doesn't have an owner, set the forceSaveunowned flag to true so it gets saved again (until somebody owns it)
+				if (_owner isEqualTo "") then {
+					 _veh setVariable ["OT_forceSaveUnowned", true, false];
+				// Otherwise, set the owner (as per usual)
+				} else {
+					[_veh,_owner] call OT_fnc_setOwner;
+				};
+
 				{
 					[_x,_veh] call {
 						params ["_it", "_veh"];

--- a/addons/overthrow_main/functions/save/fn_saveGame.sqf
+++ b/addons/overthrow_main/functions/save/fn_saveGame.sqf
@@ -105,7 +105,7 @@ private _tocheck = ((allMissionObjects "Static") + vehicles) select {
 	(alive _x)
 	&& {(typeof _x != OT_flag_IND)}
 	&& {!(typeOf _x isKindOf ["Man", _cfgVeh])}
-	&& {(_x call OT_fnc_hasOwner)}
+	&& {(_x call OT_fnc_hasOwner) or (_x getVariable ["OT_forceSaveUnowned", false])}
 	&& {(_x getVariable["OT_garrison",false]) isEqualTo false}
 };
 
@@ -144,7 +144,7 @@ private _vehicles = (_tocheck) apply {
 		[getPosWorld _x,_simCheck, 1],		// 1 stands for the new posWorld format
 		[vectorDir _x,vectorUp _x],
 		_s,
-		_x call OT_fnc_getOwner,
+		["", _x call OT_fnc_getOwner] select (_x call OT_fnc_hasOwner),		// Save an empty string if the object doesn't have an owner (yet)
 		_x getVariable ["name",""],
 		_x getVariable ["OT_init",""]
 	];

--- a/addons/overthrow_main/functions/save/fn_saveGame.sqf
+++ b/addons/overthrow_main/functions/save/fn_saveGame.sqf
@@ -140,13 +140,13 @@ private _vehicles = (_tocheck) apply {
 		};
 	};
 	private _params = [
-		_type,
-		[getPosWorld _x,_simCheck, 1],		// 1 stands for the new posWorld format
-		[vectorDir _x,vectorUp _x],
-		_s,
-		["", _x call OT_fnc_getOwner] select (_x call OT_fnc_hasOwner),		// Save an empty string if the object doesn't have an owner (yet)
-		_x getVariable ["name",""],
-		_x getVariable ["OT_init",""]
+/* 0 */		_type,
+/* 1 */		[getPosWorld _x,_simCheck, 1],		// 1 stands for the new posWorld format
+/* 2 */		[vectorDir _x,vectorUp _x],
+/* 3 */		_s,
+/* 4 */		["", _x call OT_fnc_getOwner] select (_x call OT_fnc_hasOwner),		// Save an empty string if the object doesn't have an owner (yet)
+/* 5 */		_x getVariable ["name",""],
+/* 6 */		_x getVariable ["OT_init",""]
 	];
 	if(_type isKindOf ["AllVehicles", _cfgVeh] && {!(_x getVariable ["OT_garrison",false])}) then {
 		private _veh = _x;
@@ -161,7 +161,12 @@ private _vehicles = (_tocheck) apply {
 		if(!(_attachedClass isEqualTo "") && { alive _attached }) then {
 			_att = [_attachedClass,(_attached weaponsTurret [0]) apply { [_x,_attached ammo _x] }];
 		};
-		_params pushback [fuel _x,getAllHitPointsDamage _x,_x call ace_refuel_fnc_getFuel,_x getVariable ["OT_locked",false],_ammo,_att];
+/* 7 */		_params set [7, [fuel _x,getAllHitPointsDamage _x,_x call ace_refuel_fnc_getFuel,_x getVariable ["OT_locked",false],_ammo,_att]];
+	};
+
+	// If the house is player-built, save some extra variables
+	if (_x getVariable ["OT_house_isPlayerBuilt", false]) then {
+/* 8 */		_params set [8, [_x getVariable ["OT_house_isLeased", false]]];
 	};
 	_params
 };

--- a/addons/overthrow_main/functions/save/fn_saveGame.sqf
+++ b/addons/overthrow_main/functions/save/fn_saveGame.sqf
@@ -141,7 +141,7 @@ private _vehicles = (_tocheck) apply {
 	};
 	private _params = [
 		_type,
-		[getposatl _x,_simCheck],
+		[getPosWorld _x,_simCheck, 1],		// 1 stands for the new posWorld format
 		[vectorDir _x,vectorUp _x],
 		_s,
 		_x call OT_fnc_getOwner,


### PR DESCRIPTION
**When merged this pull request will:**

- make use of `getPosWorld`/`setPosWorld` instead of `getPosATL`/`setPosWorld` in the saveGame/loadGame functions. These new commands ignore object orientation, and thus prevents issues with angled objects/vehicles "sliding" or "drifting" a little whenever the save game is reloaded,
- add backwards-compatibility for existing saves which have not yet switched to the new position format (no need for any human intervention, just plug-and-play)

This issue has been brought up on the Discord server under `#suggestions`. For further explanations regarding the positioning issue, [see this other PR I submitted in the past.](https://github.com/KillahPotatoes/KP-Liberation/pull/352)